### PR TITLE
增加加载依赖的错误信息提示

### DIFF
--- a/bin/format/sojs.js
+++ b/bin/format/sojs.js
@@ -116,6 +116,7 @@
                                 classObj[key] = require(this.getClassPath(classFullName));
                             } catch (ex) {
                                 unloadClass.push(classFullName);
+                                throw ex;
                             }
                         }
                         if (!classObj[key]) {

--- a/src/sojs.js
+++ b/src/sojs.js
@@ -207,6 +207,7 @@
                             }
                             catch (ex) {
                                 unloadClass.push(classFullName);
+                                throw ex;
                             }
                         }
 


### PR DESCRIPTION
当一个类加载依赖时，如果依赖的文件有错误，不会抛出详细的异常信息，只能人工去依赖文件中查找错误。
增加加载依赖时，保存每个依赖模块的加载错误信息，并在外层统一抛出。